### PR TITLE
Screen space conversions

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,8 @@
       </nav>
     </header> -->
     <div class="main">
-      <canvas class="canvas"></canvas>
+      <canvas class="ui-canvas"></canvas>
+      <canvas class="three-canvas"></canvas>
     </div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/ball.ts
+++ b/src/ball.ts
@@ -11,7 +11,7 @@ export default class JugglingBall extends THREE.Mesh {
   mass: number = 1;
   constructor(
     sphereGeometry: THREE.SphereGeometry,
-    material: THREE.MeshToonMaterial,
+    material: THREE.MeshToonMaterial | THREE.MeshLambertMaterial,
     startPos: number[]
   ) {
     super(sphereGeometry, material);

--- a/src/interface-sandbox.ts
+++ b/src/interface-sandbox.ts
@@ -1,0 +1,89 @@
+import { _drawCircle } from './utils';
+import InterfaceController from './interface';
+import * as THREE from 'three';
+
+const uiController = new InterfaceController();
+
+const canvas: HTMLCanvasElement | null =
+  document.querySelector('.three-canvas');
+
+const scene = new THREE.Scene();
+
+const ambientLight = new THREE.AmbientLight(0xffffff, 0.5); //* LIGHTING
+const pointLight = new THREE.PointLight(0xffffff, 1);
+pointLight.position.set(0, 0, 0);
+scene.add(ambientLight);
+scene.add(pointLight);
+
+const camera = new THREE.PerspectiveCamera( //* CAMERA
+  40,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000
+);
+camera.position.z = 20;
+
+const SPHERE_FIDELITY = 16;
+const sphereGeometry = new THREE.SphereGeometry(
+  0.3,
+  SPHERE_FIDELITY,
+  SPHERE_FIDELITY
+);
+const leftHandMaterial = new THREE.MeshLambertMaterial({ color: 0xff0000 });
+const rightHandMaterial = new THREE.MeshLambertMaterial({ color: 0x0000ff });
+
+const leftHand = new THREE.Mesh(sphereGeometry, leftHandMaterial);
+let leftWordlPoint = _screenToWorldPoint(
+  uiController.hands.left.x,
+  uiController.hands.left.y,
+  camera
+);
+let rightWordlPoint = _screenToWorldPoint(
+  uiController.hands.right.x,
+  uiController.hands.right.y,
+  camera
+);
+let leftHandScalar = camera.position.z * 10;
+leftHand.position.set(
+  leftWordlPoint.x * leftHandScalar,
+  leftWordlPoint.y * leftHandScalar,
+  0
+);
+scene.add(leftHand);
+
+const rightHand = new THREE.Mesh(sphereGeometry, rightHandMaterial);
+let rightHandScalar = camera.position.z * 10;
+rightHand.position.set(
+  rightWordlPoint.x * rightHandScalar,
+  rightWordlPoint.y * rightHandScalar,
+  0
+);
+scene.add(rightHand);
+
+function _screenToWorldPoint(
+  x: number,
+  y: number,
+  camera: THREE.PerspectiveCamera
+) {
+  let vector = new THREE.Vector3(
+    (x / window.innerWidth) * 2 - 1,
+    -(y / window.innerHeight) * 2 + 1,
+    -1
+  );
+  camera.updateMatrixWorld(true);
+  vector.unproject(camera);
+  return vector;
+}
+
+const renderer = new THREE.WebGLRenderer({
+  canvas: canvas as HTMLCanvasElement,
+});
+renderer.setSize(window.innerWidth, window.innerHeight);
+
+const animate = () => {
+  requestAnimationFrame(animate);
+  camera.updateProjectionMatrix();
+  renderer.render(scene, camera);
+};
+
+animate();

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,65 +1,64 @@
-/*
-//*TODO: Make hands global variables
-*/
-
 import { _drawCircle, _drawLine } from './utils';
 
-const Hands = {
-  left: {
-    x: window.innerWidth / 4,
-    y: window.innerHeight / 2 + 100,
-  },
-  right: {
-    x: (3 * window.innerWidth) / 4,
-    y: window.innerHeight / 2 + 100,
-  },
-};
-
-const updateHandPositions = () => {
-  const leftHandX = window.innerWidth / 4;
-  const rightHandX = window.innerWidth - leftHandX;
-  const handOffsetY = 100;
-  const handHeight = window.innerHeight / 2 + handOffsetY;
-  Hands.left = { x: leftHandX, y: handHeight };
-  Hands.right = { x: rightHandX, y: handHeight };
-};
-updateHandPositions();
-
-const canvas = document.querySelector('canvas') as HTMLCanvasElement | null;
-if (canvas === null) {
-  throw new Error('No canvas element found in the document.');
+interface Hands {
+  left: { x: number; y: number };
+  right: { x: number; y: number };
 }
 
-canvas.width = window.innerWidth;
-canvas.height = window.innerHeight;
+export default class InterfaceController {
+  canvas!: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+  hands: Hands = {
+    left: {
+      x: window.innerWidth / 4,
+      y: window.innerHeight / 2 + 100,
+    },
+    right: {
+      x: (3 * window.innerWidth) / 4,
+      y: window.innerHeight / 2 + 100,
+    },
+  };
 
-const ctx = canvas!.getContext('2d');
-if (ctx === null) {
-  throw new Error('Could not get 2d context from canvas.');
-}
-ctx.fillStyle = 'white';
-ctx.strokeStyle = 'white';
+  constructor() {
+    this.canvas = document.querySelector('.ui-canvas') as HTMLCanvasElement;
+    this.canvas.width = window.innerWidth;
+    this.canvas.height = window.innerHeight;
 
-function drawUI() {
-  ctx!.lineWidth = 2;
-  ctx!.strokeStyle = 'white';
-  ctx!.fillStyle = 'white';
-  _drawCircle(ctx!, Hands.left.x, Hands.left.y, 5); //draw hands
-  _drawCircle(ctx!, Hands.right.x, Hands.right.y, 5);
-  let centerX = window.innerWidth / 2; // draw center line
-  _drawLine(ctx!, centerX, 0, centerX, window.innerHeight);
-}
-drawUI();
+    this.ctx = this.canvas.getContext('2d') as CanvasRenderingContext2D;
+    if (this.ctx === null) {
+      throw new Error('Could not get 2d context from canvas.');
+    }
 
-function handleResize() {
-  updateHandPositions();
-  if (canvas === null) {
-    throw new Error('No canvas element found in the document.');
+    window.addEventListener('resize', () => {
+      this.updateHandPositions();
+      this.drawUI();
+    });
+    this.ctx.fillStyle = 'white';
+    this.ctx.strokeStyle = 'white';
+    this.ctx.lineWidth = 2;
+    this.updateHandPositions(); //call intitial position update and draw to canvas
+    this.drawUI();
   }
-  canvas.width = window.innerWidth;
-  canvas.height = window.innerHeight;
-  ctx!.clearRect(0, 0, canvas.width, canvas.height);
-  drawUI();
-  console.log(Hands.left.x, Hands.left.y);
+
+  private updateHandPositions = () => {
+    const leftHandX = window.innerWidth / 4;
+    const rightHandX = window.innerWidth - leftHandX;
+    const handOffsetY = 100;
+    const handHeight = window.innerHeight / 2 + handOffsetY;
+    this.hands.left = { x: leftHandX, y: handHeight };
+    this.hands.right = { x: rightHandX, y: handHeight };
+  };
+
+  private drawUI() {
+    this.canvas.width = window.innerWidth;
+    this.canvas.height = window.innerHeight;
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.ctx.fillStyle = 'white';
+    this.ctx.strokeStyle = 'white';
+    this.ctx.lineWidth = 2;
+    let centerX = window.innerWidth / 2; // draw center line
+    _drawCircle(this.ctx, this.hands.left.x, this.hands.left.y, 10); //draw this.hands
+    _drawCircle(this.ctx, this.hands.right.x, this.hands.right.y, 10);
+    _drawLine(this.ctx, centerX, 0, centerX, window.innerHeight);
+  }
 }
-window.addEventListener('resize', handleResize);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,18 @@
 import * as THREE from 'three';
-import * as dat from 'dat.gui';
 import { _drawCircle, _calculateKinematicPosition, _applyForce } from './utils';
+import InterfaceController from './interface';
 import JugglingBall from './ball';
 
-const canvas: HTMLCanvasElement | null = document.querySelector('canvas');
+const uiController = new InterfaceController();
+
+const canvas: HTMLCanvasElement | null =
+  document.querySelector('.three-canvas');
+
 const scene = new THREE.Scene();
 
 const ambientLight = new THREE.AmbientLight(0xffffff, 0.5); //* LIGHTING
-const pointLight = new THREE.PointLight(0xff0000, 1, 100);
-pointLight.position.set(1, 2, 1);
+const pointLight = new THREE.PointLight(0xffffff, 1);
+pointLight.position.set(0, 0, 0);
 scene.add(ambientLight);
 scene.add(pointLight);
 
@@ -30,14 +34,14 @@ const sphereGeometry = new THREE.SphereGeometry(
 let deltaSeperation = 3;
 
 const JugglingBallConfig = [
-  // {
-  //   startPos: [-deltaSeperation, 0, 0],
-  //   color: 0xff788a,
-  // },
-  // {
-  //   startPos: [deltaSeperation, 0, 0],
-  //   color: 0x78ffb0,
-  // },
+  {
+    startPos: [-deltaSeperation, 0, 0],
+    color: 0xff788a,
+  },
+  {
+    startPos: [deltaSeperation, 0, 0],
+    color: 0x78ffb0,
+  },
   {
     startPos: [0, deltaSeperation, 0],
     color: 0x78f4ff,
@@ -50,7 +54,7 @@ for (let ball of JugglingBallConfig) {
   balls.push(
     new JugglingBall(
       sphereGeometry,
-      new THREE.MeshToonMaterial({ color: ball.color }),
+      new THREE.MeshLambertMaterial({ color: ball.color }),
       ball.startPos
     )
   );
@@ -58,6 +62,31 @@ for (let ball of JugglingBallConfig) {
 balls.forEach((ball) => {
   scene.add(ball);
 });
+
+const markerGeometry = new THREE.SphereGeometry(
+  0.1,
+  SPHERE_FIDELITY,
+  SPHERE_FIDELITY
+);
+//CREATE MARKERS
+const leftMarker = new THREE.Mesh(
+  markerGeometry,
+  new THREE.MeshToonMaterial({ color: 0xb642f5 })
+);
+const rightMarker = new THREE.Mesh(
+  markerGeometry,
+  new THREE.MeshToonMaterial({ color: 0xb642f5 })
+);
+
+let leftMarkerPos = _screenToWorldPoint(
+  uiController.hands.left.x,
+  uiController.hands.left.y,
+  camera
+);
+console.log(leftMarkerPos);
+leftMarker.position.set(leftMarkerPos.x * 50, leftMarkerPos.y * 50, 0);
+
+scene.add(leftMarker, rightMarker);
 
 const renderer = new THREE.WebGLRenderer({ canvas: canvas! });
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -70,8 +99,6 @@ window.addEventListener('resize', resizeCanvas);
 
 let previousTime = Date.now();
 
-let enableGravity = false;
-let isPaused = false;
 const gravity = new THREE.Vector3(0, -9.8, 0);
 
 function animate() {
@@ -80,68 +107,50 @@ function animate() {
 
   previousTime = currentTime;
 
-  if (!isPaused) {
-    balls.forEach((ball) => {
-      // ball.updatePhysics(deltaTime, enableGravity ? gravity : null);
-    });
-  }
+  balls.forEach((ball) => {
+    ball.updatePhysics(deltaTime);
+  });
 
   renderer.render(scene, camera);
   requestAnimationFrame(animate);
 }
-
 animate();
 
 //TODO: Add kinematic display as a method of the ball class
 
-const PROJECTION_TIME = 1;
-const LINE_RESOLUTION = 100;
-
-// const lineGeometries = [];
-const lineMaterial = new THREE.LineBasicMaterial({ color: 0x00ff00 });
-for (let i = 0; i < balls.length; i++) {
-  let pointArray = [];
-  for (let j = 0; j < LINE_RESOLUTION; j++) {
-    const time = j * (PROJECTION_TIME / LINE_RESOLUTION);
-    let newPoint = _calculateKinematicPosition(
-      balls[i].position,
-      new THREE.Vector3(0, -9.81, 0),
-      new THREE.Vector3(0, -9.81, 0),
-      time
-    );
-    pointArray.push(newPoint);
-  }
-  let geometry = new THREE.BufferGeometry().setFromPoints(pointArray);
-  let line = new THREE.Line(geometry, lineMaterial);
-  scene.add(line);
+function _screenToWorldPoint(
+  x: number,
+  y: number,
+  camera: THREE.PerspectiveCamera
+) {
+  let vector = new THREE.Vector3(
+    (x / window.innerWidth) * 2 - 1,
+    -(y / window.innerHeight) * 2 + 1,
+    0.5
+  );
+  vector.unproject(camera);
+  return vector;
 }
 
-//* DAT GUI
-var gui = new dat.GUI({ name: 'My GUI' });
-gui
-  .add(
-    {
-      useGravity: enableGravity,
-    },
-    'useGravity'
-  )
-  .onChange(() => {
-    enableGravity = !enableGravity;
-  })
-  .name('Enable global Force (gravity)');
+// const PROJECTION_TIME = 1;
+// const LINE_RESOLUTION = 100;
 
-document.addEventListener('click', (e) => {
-  let raycaster = new THREE.Raycaster();
-  let mouse = new THREE.Vector2();
-  mouse.x = (e.clientX / window.innerWidth) * 2 - 1;
-  mouse.y = -(e.clientY / window.innerHeight) * 2 + 1;
-  raycaster.setFromCamera(mouse, camera);
-  let intersects = raycaster.intersectObjects(balls);
-  if (intersects.length > 0) {
-    let obj = intersects[0].object;
-    if (obj instanceof JugglingBall) {
-      // console.log('Clicked on ball:', obj.uuid, obj.throwForce);
-      // obj.throwBall(obj.throwForce);
-    }
-  }
-});
+// const lineMaterial = new THREE.LineBasicMaterial({ color: 0x00ff00 });
+// for (let i = 0; i < balls.length; i++) {
+//   let pointArray = [];
+//   for (let j = 0; j < LINE_RESOLUTION; j++) {
+//     const time = j * (PROJECTION_TIME / LINE_RESOLUTION);
+//     let newPoint = _calculateKinematicPosition(
+//       balls[i].position,
+//       new THREE.Vector3(0, -9.81, 0),
+//       new THREE.Vector3(0, -9.81, 0),
+//       time
+//     );
+//     pointArray.push(newPoint);
+//   }
+//   let geometry = new THREE.BufferGeometry().setFromPoints(pointArray);
+//   let line = new THREE.Line(geometry, lineMaterial);
+//   scene.add(line);
+// }
+
+//create a function that takes the x and y coordinated of a screen point and returns a world point in 3d space at a specified depth (z)

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,9 +22,54 @@ const camera = new THREE.PerspectiveCamera( //* CAMERA
   0.1,
   1000
 );
-camera.position.z = 20;
+camera.position.z = 15;
 
 const SPHERE_FIDELITY = 16;
+
+const markerGeometry = new THREE.SphereGeometry(
+  0.1,
+  SPHERE_FIDELITY,
+  SPHERE_FIDELITY
+);
+
+const leftHand = new THREE.Mesh(
+  markerGeometry,
+  new THREE.MeshToonMaterial({ color: 0xb642f5 })
+);
+const rightHand = new THREE.Mesh(
+  markerGeometry,
+  new THREE.MeshToonMaterial({ color: 0xb642f5 })
+);
+
+function setObjectWorldPositions() {
+  let leftWorldPoint = _screenToWorldPoint(
+    uiController.hands.left.x,
+    uiController.hands.left.y,
+    camera
+  );
+  let rightWorldPoint = _screenToWorldPoint(
+    uiController.hands.right.x,
+    uiController.hands.right.y,
+    camera
+  );
+
+  let worldPointScalar = camera.position.z * 10;
+
+  leftHand.position.set(
+    leftWorldPoint.x * worldPointScalar,
+    leftWorldPoint.y * worldPointScalar,
+    0
+  );
+  rightHand.position.set(
+    rightWorldPoint.x * worldPointScalar,
+    rightWorldPoint.y * worldPointScalar,
+    0
+  );
+}
+setObjectWorldPositions();
+scene.add(leftHand);
+scene.add(rightHand);
+
 const sphereGeometry = new THREE.SphereGeometry(
   0.5,
   SPHERE_FIDELITY,
@@ -63,60 +108,20 @@ balls.forEach((ball) => {
   scene.add(ball);
 });
 
-const markerGeometry = new THREE.SphereGeometry(
-  0.1,
-  SPHERE_FIDELITY,
-  SPHERE_FIDELITY
-);
-
-const leftHand = new THREE.Mesh(
-  markerGeometry,
-  new THREE.MeshToonMaterial({ color: 0xb642f5 })
-);
-
-const rightHand = new THREE.Mesh(
-  markerGeometry,
-  new THREE.MeshToonMaterial({ color: 0xb642f5 })
-);
-let leftWorldPoint = _screenToWorldPoint(
-  uiController.hands.left.x,
-  uiController.hands.left.y,
-  camera
-);
-let rightWorldPoint = _screenToWorldPoint(
-  uiController.hands.right.x,
-  uiController.hands.right.y,
-  camera
-);
-
-let worldPointScalar = camera.position.z * 10;
-
-leftHand.position.set(
-  leftWorldPoint.x * worldPointScalar,
-  leftWorldPoint.y * worldPointScalar,
-  0
-);
-scene.add(leftHand);
-
-rightHand.position.set(
-  rightWorldPoint.x * worldPointScalar,
-  rightWorldPoint.y * worldPointScalar,
-  0
-);
-scene.add(rightHand);
-
 const renderer = new THREE.WebGLRenderer({ canvas: canvas! });
 renderer.setSize(window.innerWidth, window.innerHeight);
+
 const resizeCanvas = () => {
   renderer.setSize(window.innerWidth, window.innerHeight);
   camera.aspect = window.innerWidth / window.innerHeight;
   camera.updateProjectionMatrix();
+  setObjectWorldPositions();
 };
 window.addEventListener('resize', resizeCanvas);
 
 let previousTime = Date.now();
 
-const gravity = new THREE.Vector3(0, -9.8, 0);
+// const gravity = new THREE.Vector3(0, -9.8, 0);
 
 function animate() {
   let currentTime = Date.now();

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,25 +68,42 @@ const markerGeometry = new THREE.SphereGeometry(
   SPHERE_FIDELITY,
   SPHERE_FIDELITY
 );
-//CREATE MARKERS
-const leftMarker = new THREE.Mesh(
-  markerGeometry,
-  new THREE.MeshToonMaterial({ color: 0xb642f5 })
-);
-const rightMarker = new THREE.Mesh(
+
+const leftHand = new THREE.Mesh(
   markerGeometry,
   new THREE.MeshToonMaterial({ color: 0xb642f5 })
 );
 
-let leftMarkerPos = _screenToWorldPoint(
+const rightHand = new THREE.Mesh(
+  markerGeometry,
+  new THREE.MeshToonMaterial({ color: 0xb642f5 })
+);
+let leftWorldPoint = _screenToWorldPoint(
   uiController.hands.left.x,
   uiController.hands.left.y,
   camera
 );
-console.log(leftMarkerPos);
-leftMarker.position.set(leftMarkerPos.x * 50, leftMarkerPos.y * 50, 0);
+let rightWorldPoint = _screenToWorldPoint(
+  uiController.hands.right.x,
+  uiController.hands.right.y,
+  camera
+);
 
-scene.add(leftMarker, rightMarker);
+let worldPointScalar = camera.position.z * 10;
+
+leftHand.position.set(
+  leftWorldPoint.x * worldPointScalar,
+  leftWorldPoint.y * worldPointScalar,
+  0
+);
+scene.add(leftHand);
+
+rightHand.position.set(
+  rightWorldPoint.x * worldPointScalar,
+  rightWorldPoint.y * worldPointScalar,
+  0
+);
+scene.add(rightHand);
 
 const renderer = new THREE.WebGLRenderer({ canvas: canvas! });
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -116,8 +133,6 @@ function animate() {
 }
 animate();
 
-//TODO: Add kinematic display as a method of the ball class
-
 function _screenToWorldPoint(
   x: number,
   y: number,
@@ -126,11 +141,14 @@ function _screenToWorldPoint(
   let vector = new THREE.Vector3(
     (x / window.innerWidth) * 2 - 1,
     -(y / window.innerHeight) * 2 + 1,
-    0.5
+    -1
   );
+  camera.updateMatrixWorld(true);
   vector.unproject(camera);
   return vector;
 }
+
+// TODO: Add kinematic display as a method of the ball class
 
 // const PROJECTION_TIME = 1;
 // const LINE_RESOLUTION = 100;

--- a/src/style.css
+++ b/src/style.css
@@ -22,18 +22,28 @@ html {
 body {
   min-height: 100%;
   height: 100%;
-  border: 4px solid rgb(157, 195, 240);
 }
 
 .main {
+  /* border: 4px solid rgb(157, 195, 240); */
   height: 100%;
   overflow-y: hidden;
+  position: relative;
 }
 
 canvas {
-  border: 4px solid rgb(199, 68, 68);
+  /* border: 4px solid rgb(199, 68, 68); */
   width: 100%;
   height: 100%;
+}
+.ui-canvas {
+  z-index: -1;
+  position: absolute;
+}
+
+.three-canvas {
+  z-index: -2;
+  position: absolute;
 }
 
 .logo {


### PR DESCRIPTION

Converted left/right screen space points calculated in the interface controller to world space.
Added CSS to fix position and layering of the 'UI' and 'THREE.js' canvases.
**note** The conversion uses the vector.unproject() method using a NDC vector with the z component being -1.
- We scale the resulting vector using the following scalar => worldPointScalar = camera.position.z * 10; 
- This is fine for now but I would like to look into the reasoning for the above calculations.